### PR TITLE
Try executing swift package generate-xcodeproj outside of Rake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
 install:
 - bundle install
 script:
+- travis_wait swift package generate-xcodeproj
 - bundle exec rake test
 - bundle exec rake release
 - |


### PR DESCRIPTION
### Short description 📝
Test on Travis CI

### Solution 📦
Not sure it will be fixed yet

### Implementation 👩‍💻👨‍💻
In brief, I'm calling `swift package generate-xcodeproj` outside of `rake test` and with `travis_wait` in the case it takes more than 10 minutes without output.