### PR TITLE
Use GenerationOptions to generate build configurations

### DIFF
--- a/App.xcodeproj/project.pbxproj
+++ b/App.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 		3D92B79320A83BC3006711E5 /* ProjectGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D92B79220A83BC3006711E5 /* ProjectGroups.swift */; };
 		3D92B7E720A84888006711E5 /* ProjectGroupsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D92B7E620A84888006711E5 /* ProjectGroupsTests.swift */; };
 		3D92B7E920A857D9006711E5 /* GenerationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D92B7E820A857D9006711E5 /* GenerationOptions.swift */; };
+		3D92B80420AABC3A006711E5 /* GenerateCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D92B80320AABC3A006711E5 /* GenerateCommandTests.swift */; };
+		3D92B80520AABC3A006711E5 /* GenerateCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D92B80320AABC3A006711E5 /* GenerateCommandTests.swift */; };
+		3D92B80720AABE55006711E5 /* MockGraphLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D92B80620AABE55006711E5 /* MockGraphLoader.swift */; };
+		3D92B80920AABEC7006711E5 /* MockWorkspaceGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D92B80820AABEC7006711E5 /* MockWorkspaceGenerator.swift */; };
 		66F6DC2FC19AB1F6D332D8E8 /* ArgumentParserResult+TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F6D37333CBFF51EA0098DD /* ArgumentParserResult+TestData.swift */; };
 		B9013DD5206FEEDF007B1A34 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9013DD4206FEEDF007B1A34 /* Sparkle.framework */; };
 		B9013DD6206FEEEA007B1A34 /* Sparkle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B9013DD4206FEEDF007B1A34 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -243,6 +247,9 @@
 		3D92B79220A83BC3006711E5 /* ProjectGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGroups.swift; sourceTree = "<group>"; };
 		3D92B7E620A84888006711E5 /* ProjectGroupsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGroupsTests.swift; sourceTree = "<group>"; };
 		3D92B7E820A857D9006711E5 /* GenerationOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationOptions.swift; sourceTree = "<group>"; };
+		3D92B80320AABC3A006711E5 /* GenerateCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateCommandTests.swift; sourceTree = "<group>"; };
+		3D92B80620AABE55006711E5 /* MockGraphLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGraphLoader.swift; sourceTree = "<group>"; };
+		3D92B80820AABEC7006711E5 /* MockWorkspaceGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWorkspaceGenerator.swift; sourceTree = "<group>"; };
 		66F6D37333CBFF51EA0098DD /* ArgumentParserResult+TestData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ArgumentParserResult+TestData.swift"; sourceTree = "<group>"; };
 		B9013DD4206FEEDF007B1A34 /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Sparkle.framework; sourceTree = "<group>"; };
 		B9157D5220A24B4300C2EEBA /* VersionCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionCommandTests.swift; sourceTree = "<group>"; };
@@ -426,6 +433,7 @@
 			children = (
 				B92BF9F0207559E600EE4EBD /* MockGraphLoaderCache.swift */,
 				B92BF9F620755B8500EE4EBD /* MockManifestLoader.swift */,
+				3D92B80620AABE55006711E5 /* MockGraphLoader.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -467,6 +475,7 @@
 			isa = PBXGroup;
 			children = (
 				B9589608208B4E8E00F00ACF /* MockProjectGenerator.swift */,
+				3D92B80820AABEC7006711E5 /* MockWorkspaceGenerator.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -837,6 +846,7 @@
 				B9E2DCC72089B78D0061DF86 /* DumpCommandTests.swift */,
 				B9F1EDCE208CD0B800477835 /* InitCommandTests.swift */,
 				B9157D5220A24B4300C2EEBA /* VersionCommandTests.swift */,
+				3D92B80320AABC3A006711E5 /* GenerateCommandTests.swift */,
 			);
 			path = Commands;
 			sourceTree = "<group>";
@@ -1124,6 +1134,7 @@
 				B9E2DC9620872B3A0061DF86 /* MockGraphLoaderCache.swift in Sources */,
 				B9E2DC9520872B300061DF86 /* MockUpdateController.swift in Sources */,
 				B9E2DC9D20872D3B0061DF86 /* MockPrinter.swift in Sources */,
+				3D92B80720AABE55006711E5 /* MockGraphLoader.swift in Sources */,
 				B9B5943B209C176C00C59DA2 /* ErrorHandlerTests.swift in Sources */,
 				B9589604208A405D00F00ACF /* ProductTests .swift in Sources */,
 				B9E2DCC42088EEFC0061DF86 /* CommandRegistryTests.swift in Sources */,
@@ -1142,6 +1153,7 @@
 				B9F1EDFB208D24F700477835 /* ProjectValidatorTests.swift in Sources */,
 				B918A2312093680600E64FBE /* MockErrorHandler.swift in Sources */,
 				B9E2DC9720872B5D0061DF86 /* MockManifestLoader.swift in Sources */,
+				3D92B80920AABEC7006711E5 /* MockWorkspaceGenerator.swift in Sources */,
 				B9E2DCC82089B78D0061DF86 /* DumpCommandTests.swift in Sources */,
 				3D92B78E20A8298F006711E5 /* ConfigGeneratorTests.swift in Sources */,
 				B9E2DCA32087651D0061DF86 /* Project+TestData.swift in Sources */,
@@ -1162,6 +1174,7 @@
 				B9589607208B4E4700F00ACF /* WorkspaceGeneratorTests.swift in Sources */,
 				B9589602208A3CBA00F00ACF /* PlatformTests.swift in Sources */,
 				B958960D208B607400F00ACF /* GraphCircularDetectorTests.swift in Sources */,
+				3D92B80520AABC3A006711E5 /* GenerateCommandTests.swift in Sources */,
 				B95895FD208A361D00F00ACF /* GraphLoadingErrorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1170,6 +1183,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3D92B80420AABC3A006711E5 /* GenerateCommandTests.swift in Sources */,
 				B94C7FC62062B8A8009BF596 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/App/xcbuddykit/Sources/Commands/GenerateCommand.swift
+++ b/App/xcbuddykit/Sources/Commands/GenerateCommand.swift
@@ -34,6 +34,9 @@ public class GenerateCommand: NSObject, Command {
     /// Path argument.
     let pathArgument: OptionArgument<String>
 
+    /// Config argument.
+    let configArgument: OptionArgument<String>
+
     /// Initializes the generate command with the argument parser.
     ///
     /// - Parameter parser: argument parser.
@@ -66,8 +69,13 @@ public class GenerateCommand: NSObject, Command {
         pathArgument = subParser.add(option: "--path",
                                      shortName: "-p",
                                      kind: String.self,
-                                     usage: "The path where the Project.swift file will be generated",
+                                     usage: "The path where the Project.swift file will be generated.",
                                      completion: .filename)
+        configArgument = subParser.add(option: "--config",
+                                       shortName: "-c",
+                                       kind: String.self,
+                                       usage: "The configuration that will be generated.",
+                                       completion: .filename)
     }
 
     /// Runs the command.
@@ -76,12 +84,25 @@ public class GenerateCommand: NSObject, Command {
     /// - Throws: an error if the command cannot be executed.
     public func run(with arguments: ArgumentParser.Result) {
         context.errorHandler.try {
+            // Path
             var path: AbsolutePath! = arguments.get(pathArgument).map({ AbsolutePath($0) })
             if path == nil {
                 path = AbsolutePath.current
             }
+
+            // Config
+            var config: BuildConfiguration = .debug
+            if let configString = arguments.get(configArgument) {
+                guard let buildConfiguration = BuildConfiguration(rawValue: configString) else {
+                    let error = ArgumentParserError.invalidValue(argument: "config",
+                                                                 error: ArgumentConversionError.custom("config can only be debug or release"))
+                    self.context.errorHandler.fatal(error: FatalError.abort(error))
+                    return
+                }
+                config = buildConfiguration
+            }
             let context = try GeneratorContext(graph: graphLoader.load(path: path))
-            try workspaceGenerator.generate(path: path, context: context, options: GenerationOptions())
+            try workspaceGenerator.generate(path: path, context: context, options: GenerationOptions(buildConfiguration: config))
             self.context.printer.print(section: "Generate command succeeded 🎉")
         }
     }

--- a/App/xcbuddykit/Sources/Commands/GenerateCommand.swift
+++ b/App/xcbuddykit/Sources/Commands/GenerateCommand.swift
@@ -81,7 +81,7 @@ public class GenerateCommand: NSObject, Command {
                 path = AbsolutePath.current
             }
             let context = try GeneratorContext(graph: graphLoader.load(path: path))
-            try workspaceGenerator.generate(path: path, context: context)
+            try workspaceGenerator.generate(path: path, context: context, options: GenerationOptions())
             self.context.printer.print(section: "Generate command succeeded 🎉")
         }
     }

--- a/App/xcbuddykit/Sources/Commands/GenerateCommand.swift
+++ b/App/xcbuddykit/Sources/Commands/GenerateCommand.swift
@@ -2,16 +2,6 @@ import Basic
 import Foundation
 import Utility
 
-enum GenerateCommandError: Error, ErrorStringConvertible, Equatable {
-    static func == (_: GenerateCommandError, _: GenerateCommandError) -> Bool {
-        return true
-    }
-
-    var errorDescription: String {
-        return ""
-    }
-}
-
 public class GenerateCommand: NSObject, Command {
     /// Command name (static).
     public static let command = "generate"
@@ -84,26 +74,42 @@ public class GenerateCommand: NSObject, Command {
     /// - Throws: an error if the command cannot be executed.
     public func run(with arguments: ArgumentParser.Result) {
         context.errorHandler.try {
-            // Path
-            var path: AbsolutePath! = arguments.get(pathArgument).map({ AbsolutePath($0) })
-            if path == nil {
-                path = AbsolutePath.current
-            }
-
-            // Config
-            var config: BuildConfiguration = .debug
-            if let configString = arguments.get(configArgument) {
-                guard let buildConfiguration = BuildConfiguration(rawValue: configString) else {
-                    let error = ArgumentParserError.invalidValue(argument: "config",
-                                                                 error: ArgumentConversionError.custom("config can only be debug or release"))
-                    self.context.errorHandler.fatal(error: FatalError.abort(error))
-                    return
-                }
-                config = buildConfiguration
-            }
+            let path = parsePath(arguments: arguments)
+            let config = parseConfig(arguments: arguments)
             let context = try GeneratorContext(graph: graphLoader.load(path: path))
             try workspaceGenerator.generate(path: path, context: context, options: GenerationOptions(buildConfiguration: config))
             self.context.printer.print(section: "Generate command succeeded 🎉")
         }
+    }
+
+    /// Parses the arguments and returns the path to the folder where the manifest file is.
+    ///
+    /// - Parameter arguments: argument parser result.
+    /// - Returns: the path to th efolder where the manifest is.
+    private func parsePath(arguments: ArgumentParser.Result) -> AbsolutePath {
+        var path: AbsolutePath! = arguments.get(pathArgument).map({ AbsolutePath($0) })
+        if path == nil {
+            path = AbsolutePath.current
+        }
+        return path
+    }
+
+    /// Parses the arguments and returns the build configuration that we should use for generating the projects.
+    ///
+    /// - Parameters:
+    ///     - arguments: argument parser result.
+    /// - Returns: The build configuration.
+    private func parseConfig(arguments: ArgumentParser.Result) -> BuildConfiguration {
+        var config: BuildConfiguration = .debug
+        if let configString = arguments.get(configArgument) {
+            guard let buildConfiguration = BuildConfiguration(rawValue: configString.lowercased()) else {
+                let error = ArgumentParserError.invalidValue(argument: "config",
+                                                             error: ArgumentConversionError.custom("config can only be debug or release"))
+                context.errorHandler.fatal(error: FatalError.abort(error))
+                return .debug
+            }
+            config = buildConfiguration
+        }
+        return config
     }
 }

--- a/App/xcbuddykit/Sources/Generator/ProjectGenerator.swift
+++ b/App/xcbuddykit/Sources/Generator/ProjectGenerator.swift
@@ -11,9 +11,10 @@ protocol ProjectGenerating: AnyObject {
     ///   - sourceRootPath: path to the folder that contains the project that is being generated.
     ///     If it's not specified, it'll use the same folder where the spec is defined.
     ///   - context: generation context.
+    ///   - options: generation options.
     /// - Returns: the path where the project has been generated.
     /// - Throws: an error if the generation fails.
-    func generate(project: Project, sourceRootPath: AbsolutePath?, context: GeneratorContexting) throws -> AbsolutePath
+    func generate(project: Project, sourceRootPath: AbsolutePath?, context: GeneratorContexting, options: GenerationOptions) throws -> AbsolutePath
 }
 
 /// Project generator.
@@ -37,7 +38,8 @@ final class ProjectGenerator: ProjectGenerating {
 
     func generate(project: Project,
                   sourceRootPath: AbsolutePath? = nil,
-                  context: GeneratorContexting) throws -> AbsolutePath {
+                  context: GeneratorContexting,
+                  options: GenerationOptions) throws -> AbsolutePath {
         context.printer.print("Generating project \(project.name)")
 
         // Getting the path.
@@ -58,7 +60,8 @@ final class ProjectGenerator: ProjectGenerating {
                                                                                    pbxproj: pbxproj,
                                                                                    groups: groups,
                                                                                    sourceRootPath: sourceRootPath,
-                                                                                   context: context)
+                                                                                   context: context,
+                                                                                   options: options)
 
         /// Generate project object.
         let pbxProject = PBXProject(name: project.name,
@@ -82,7 +85,8 @@ final class ProjectGenerator: ProjectGenerating {
                                                     pbxProject: pbxProject,
                                                     groups: groups,
                                                     sourceRootPath: sourceRootPath,
-                                                    context: context)
+                                                    context: context,
+                                                    options: options)
         try project.targets.forEach { target in
             try targetGenerator.generateTarget(target: target,
                                                pbxproj: pbxproj,

--- a/App/xcbuddykit/Sources/Generator/TargetGenerator.swift
+++ b/App/xcbuddykit/Sources/Generator/TargetGenerator.swift
@@ -13,13 +13,15 @@ protocol TargetGenerating: AnyObject {
     ///   - groups: Project groups.
     ///   - sourceRootPath: Path to the folder that contains the project that is getting generated.
     ///   - context: generation context.
+    ///   - options: Generation options.
     /// - Throws: an error if the generation fails.
     func generateManifestsTarget(project: Project,
                                  pbxproj: PBXProj,
                                  pbxProject: PBXProject,
                                  groups: ProjectGroups,
                                  sourceRootPath: AbsolutePath,
-                                 context: GeneratorContexting) throws
+                                 context: GeneratorContexting,
+                                 options: GenerationOptions) throws
 
     /// Generates a native target.
     ///
@@ -67,13 +69,15 @@ final class TargetGenerator: TargetGenerating {
     ///   - groups: Project groups.
     ///   - sourceRootPath: Path to the folder that contains the project that is getting generated.
     ///   - context: generation context.
+    ///   - options: generation options.
     /// - Throws: an error if the generation fails.
     func generateManifestsTarget(project: Project,
                                  pbxproj: PBXProj,
                                  pbxProject: PBXProject,
                                  groups: ProjectGroups,
                                  sourceRootPath: AbsolutePath,
-                                 context: GeneratorContexting) throws {
+                                 context: GeneratorContexting,
+                                 options: GenerationOptions) throws {
         /// Names
         let name = "\(project.name)Description"
         let frameworkName = "\(name).framework"
@@ -101,7 +105,9 @@ final class TargetGenerator: TargetGenerating {
         }
 
         // Configuration
-        let configurationListReference = try configGenerator.generateManifestsConfig(pbxproj: pbxproj, context: context)
+        let configurationListReference = try configGenerator.generateManifestsConfig(pbxproj: pbxproj,
+                                                                                     context: context,
+                                                                                     options: options)
 
         // Build phases
         let sourcesPhase = PBXSourcesBuildPhase(files: [])

--- a/App/xcbuddykit/Sources/Generator/WorkspaceGenerator.swift
+++ b/App/xcbuddykit/Sources/Generator/WorkspaceGenerator.swift
@@ -9,9 +9,11 @@ protocol WorkspaceGenerating: AnyObject {
     /// - Parameters:
     ///   - path: path where the workspace should be generated.
     ///   - context: generator context.
+    ///   - options: generation options.
     /// - Throws: throw an error if the generation fails.
     func generate(path: AbsolutePath,
-                  context: GeneratorContexting) throws
+                  context: GeneratorContexting,
+                  options: GenerationOptions) throws
 }
 
 /// Workspace generator.
@@ -31,16 +33,21 @@ final class WorkspaceGenerator: WorkspaceGenerating {
     /// - Parameters:
     ///   - path: path where the workspace should be generated.
     ///   - context: generator context.
+    ///   - options: generation options.
     /// - Throws: throw an error if the generation fails.
     func generate(path: AbsolutePath,
-                  context: GeneratorContexting) throws {
+                  context: GeneratorContexting,
+                  options: GenerationOptions) throws {
         let workspaceName = "\(context.graph.name).xcworkspace"
         context.printer.print(section: "Generating workspace \(workspaceName)")
         let workspacePath = path.appending(component: workspaceName)
         let workspaceData = XCWorkspaceData(children: [])
         let workspace = XCWorkspace(data: workspaceData)
         try context.graph.projects.forEach { project in
-            let xcodeprojPath = try projectGenerator.generate(project: project, sourceRootPath: nil, context: context)
+            let xcodeprojPath = try projectGenerator.generate(project: project,
+                                                              sourceRootPath: nil,
+                                                              context: context,
+                                                              options: options)
             let relativePath = xcodeprojPath.relative(to: path)
             let location = XCWorkspaceDataElementLocationType.group(relativePath.asString)
             let fileRef = XCWorkspaceDataFileRef(location: location)

--- a/App/xcbuddykit/Tests/Commands/GenerateCommandTests.swift
+++ b/App/xcbuddykit/Tests/Commands/GenerateCommandTests.swift
@@ -1,0 +1,64 @@
+import Basic
+import Foundation
+import Utility
+@testable import xcbuddykit
+@testable import xcodeproj
+import XCTest
+
+final class GenerateCommandTests: XCTestCase {
+    var subject: GenerateCommand!
+    var errorHandler: MockErrorHandler!
+    var graphLoader: MockGraphLoader!
+    var workspaceGenerator: MockWorkspaceGenerator!
+    var parser: ArgumentParser!
+    var printer: MockPrinter!
+
+    override func setUp() {
+        super.setUp()
+        printer = MockPrinter()
+        errorHandler = MockErrorHandler()
+        let graphLoaderContext = GraphLoaderContext(errorHandler: errorHandler)
+        let commandsContext = CommandsContext(printer: printer, errorHandler: errorHandler)
+        graphLoader = MockGraphLoader()
+        workspaceGenerator = MockWorkspaceGenerator()
+        parser = ArgumentParser.test()
+        subject = GenerateCommand(graphLoaderContext: graphLoaderContext,
+                                  graphLoader: graphLoader,
+                                  workspaceGenerator: workspaceGenerator,
+                                  parser: parser,
+                                  context: commandsContext)
+    }
+
+    func test_command() {
+        XCTAssertEqual(GenerateCommand.command, "generate")
+    }
+
+    func test_overview() {
+        XCTAssertEqual(GenerateCommand.overview, "Generates an Xcode workspace to start working on the project.")
+    }
+
+    func test_run_fatalErrors_when_theConfigIsInvalid() throws {
+        let result = try parser.parse([GenerateCommand.command, "-c", "invalid_config"])
+        subject.run(with: result)
+        XCTAssertNotNil(errorHandler.fatalErrorArgs.first)
+    }
+
+    func test_run_fatalErrors_when_theworkspaceGenerationFails() throws {
+        let result = try parser.parse([GenerateCommand.command, "-c", "Debug"])
+        var configuration: BuildConfiguration?
+        let error = NSError.test()
+        workspaceGenerator.generateStub = { _, _, options in
+            configuration = options.buildConfiguration
+            throw error
+        }
+        subject.run(with: result)
+        XCTAssertEqual(configuration, .debug)
+        XCTAssertEqual(errorHandler.tryErrors.first as NSError?, error)
+    }
+
+    func test_run_prints() throws {
+        let result = try parser.parse([GenerateCommand.command, "-c", "Debug"])
+        subject.run(with: result)
+        XCTAssertEqual(printer.printSectionArgs.first, "Generate command succeeded 🎉")
+    }
+}

--- a/App/xcbuddykit/Tests/Generator/Mocks/MockProjectGenerator.swift
+++ b/App/xcbuddykit/Tests/Generator/Mocks/MockProjectGenerator.swift
@@ -3,7 +3,7 @@ import Foundation
 @testable import xcbuddykit
 
 final class MockProjectGenerator: ProjectGenerating {
-    func generate(project _: Project, sourceRootPath _: AbsolutePath?, context _: GeneratorContexting) throws -> AbsolutePath {
+    func generate(project _: Project, sourceRootPath _: AbsolutePath?, context _: GeneratorContexting, options _: GenerationOptions) throws -> AbsolutePath {
         return AbsolutePath("/")
     }
 }

--- a/App/xcbuddykit/Tests/Generator/Mocks/MockWorkspaceGenerator.swift
+++ b/App/xcbuddykit/Tests/Generator/Mocks/MockWorkspaceGenerator.swift
@@ -1,0 +1,13 @@
+import Basic
+import Foundation
+@testable import xcbuddykit
+
+final class MockWorkspaceGenerator: WorkspaceGenerating {
+    var generateStub: ((AbsolutePath, GeneratorContexting, GenerationOptions) throws -> Void)?
+
+    func generate(path: AbsolutePath,
+                  context: GeneratorContexting,
+                  options: GenerationOptions) throws {
+        try generateStub?(path, context, options)
+    }
+}

--- a/App/xcbuddykit/Tests/Loader/Mocks/MockGraphLoader.swift
+++ b/App/xcbuddykit/Tests/Loader/Mocks/MockGraphLoader.swift
@@ -1,0 +1,11 @@
+import Basic
+import Foundation
+@testable import xcbuddykit
+
+final class MockGraphLoader: GraphLoading {
+    var loadStub: ((AbsolutePath) throws -> Graph)?
+
+    func load(path: AbsolutePath) throws -> Graph {
+        return try loadStub?(path) ?? Graph.test()
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 * Version command https://github.com/xcbuddy/xcbuddy/pull/25 by @pepibumur.
+* Generate only the specified configurations https://github.com/xcbuddy/xcbuddy/pull/27 by @pepibumur.
 
 ### Changed
 


### PR DESCRIPTION
### Short description 📝
Instead of generating `Debug` and `Release` configurations, this PR updates the generators to generate only the configuration that is specified in the passed options.

### Implementation 👩‍💻👨‍💻
- Pass options through the generators.
- Use it from the `ConfigGenerator` to generate only the necessary configurations.