### PR TITLE
Add sources build phase generation

### DIFF
--- a/App.xcodeproj/project.pbxproj
+++ b/App.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3D4C0BA220A6ED37003D09B0 /* CommandCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4C0BA120A6ED37003D09B0 /* CommandCheck.swift */; };
 		3D7E6C6220AC79DD00360C02 /* ProjectFileElementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7E6C6120AC79DD00360C02 /* ProjectFileElementsTests.swift */; };
 		3D7E6CDF20AEC69F00360C02 /* BuildPhaseGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7E6CDE20AEC69F00360C02 /* BuildPhaseGenerator.swift */; };
+		3D7E6CE120AECC9B00360C02 /* BuildPhaseGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7E6CE020AECC9B00360C02 /* BuildPhaseGeneratorTests.swift */; };
 		3D92B77B20A818CD006711E5 /* CommandCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4C0BA320A81828003D09B0 /* CommandCheckTests.swift */; };
 		3D92B77D20A821A6006711E5 /* MockCommandCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D92B77C20A821A6006711E5 /* MockCommandCheck.swift */; };
 		3D92B78020A823FF006711E5 /* NSError+TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D92B77F20A823FF006711E5 /* NSError+TestData.swift */; };
@@ -242,6 +243,7 @@
 		3D4C0BA320A81828003D09B0 /* CommandCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandCheckTests.swift; sourceTree = "<group>"; };
 		3D7E6C6120AC79DD00360C02 /* ProjectFileElementsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectFileElementsTests.swift; sourceTree = "<group>"; };
 		3D7E6CDE20AEC69F00360C02 /* BuildPhaseGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildPhaseGenerator.swift; sourceTree = "<group>"; };
+		3D7E6CE020AECC9B00360C02 /* BuildPhaseGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildPhaseGeneratorTests.swift; sourceTree = "<group>"; };
 		3D92B77C20A821A6006711E5 /* MockCommandCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCommandCheck.swift; sourceTree = "<group>"; };
 		3D92B77F20A823FF006711E5 /* NSError+TestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSError+TestData.swift"; sourceTree = "<group>"; };
 		3D92B78D20A8298F006711E5 /* ConfigGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigGeneratorTests.swift; sourceTree = "<group>"; };
@@ -690,6 +692,7 @@
 				3D92B78D20A8298F006711E5 /* ConfigGeneratorTests.swift */,
 				3D92B7E620A84888006711E5 /* ProjectGroupsTests.swift */,
 				3D7E6C6120AC79DD00360C02 /* ProjectFileElementsTests.swift */,
+				3D7E6CE020AECC9B00360C02 /* BuildPhaseGeneratorTests.swift */,
 			);
 			path = Generator;
 			sourceTree = "<group>";
@@ -1172,6 +1175,7 @@
 				B9F1EDCF208CD0B800477835 /* InitCommandTests.swift in Sources */,
 				B9F1EDF3208D200C00477835 /* Scheme+TestData.swift in Sources */,
 				B9553DEF2090F6EC00050311 /* MockShell.swift in Sources */,
+				3D7E6CE120AECC9B00360C02 /* BuildPhaseGeneratorTests.swift in Sources */,
 				B9E2DC9920872C0F0061DF86 /* MockFileHandler.swift in Sources */,
 				B9589609208B4E8E00F00ACF /* MockProjectGenerator.swift in Sources */,
 				B9E2DC9F20872D450061DF86 /* MockLogger.swift in Sources */,

--- a/App.xcodeproj/project.pbxproj
+++ b/App.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		3D4C0B9C20A6C470003D09B0 /* FileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4C0B9B20A6C470003D09B0 /* FileGenerator.swift */; };
 		3D4C0BA220A6ED37003D09B0 /* CommandCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4C0BA120A6ED37003D09B0 /* CommandCheck.swift */; };
 		3D7E6C6220AC79DD00360C02 /* ProjectFileElementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7E6C6120AC79DD00360C02 /* ProjectFileElementsTests.swift */; };
+		3D7E6CDF20AEC69F00360C02 /* BuildPhaseGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7E6CDE20AEC69F00360C02 /* BuildPhaseGenerator.swift */; };
 		3D92B77B20A818CD006711E5 /* CommandCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4C0BA320A81828003D09B0 /* CommandCheckTests.swift */; };
 		3D92B77D20A821A6006711E5 /* MockCommandCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D92B77C20A821A6006711E5 /* MockCommandCheck.swift */; };
 		3D92B78020A823FF006711E5 /* NSError+TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D92B77F20A823FF006711E5 /* NSError+TestData.swift */; };
@@ -240,6 +241,7 @@
 		3D4C0BA120A6ED37003D09B0 /* CommandCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandCheck.swift; sourceTree = "<group>"; };
 		3D4C0BA320A81828003D09B0 /* CommandCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandCheckTests.swift; sourceTree = "<group>"; };
 		3D7E6C6120AC79DD00360C02 /* ProjectFileElementsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectFileElementsTests.swift; sourceTree = "<group>"; };
+		3D7E6CDE20AEC69F00360C02 /* BuildPhaseGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildPhaseGenerator.swift; sourceTree = "<group>"; };
 		3D92B77C20A821A6006711E5 /* MockCommandCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCommandCheck.swift; sourceTree = "<group>"; };
 		3D92B77F20A823FF006711E5 /* NSError+TestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSError+TestData.swift"; sourceTree = "<group>"; };
 		3D92B78D20A8298F006711E5 /* ConfigGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigGeneratorTests.swift; sourceTree = "<group>"; };
@@ -674,6 +676,7 @@
 				3D92B79220A83BC3006711E5 /* ProjectGroups.swift */,
 				3D92B7E820A857D9006711E5 /* GenerationOptions.swift */,
 				3D92B80A20AAFC2D006711E5 /* ProjectFileElements.swift */,
+				3D7E6CDE20AEC69F00360C02 /* BuildPhaseGenerator.swift */,
 			);
 			path = Generator;
 			sourceTree = "<group>";
@@ -1126,6 +1129,7 @@
 				B95895FB208A2FFB00F00ACF /* WorkspaceGenerator.swift in Sources */,
 				B9589600208A37B700F00ACF /* GraphJSONInitiatable.swift in Sources */,
 				B9E65C99208F8B2200A9D7AC /* GenerateCommand.swift in Sources */,
+				3D7E6CDF20AEC69F00360C02 /* BuildPhaseGenerator.swift in Sources */,
 				B9F1EDF8208D22D900477835 /* TargetValidator.swift in Sources */,
 				B9B6299F20864E2300EE9E07 /* Constants.swift in Sources */,
 				B9F1EDF6208D228600477835 /* ProjectValidator.swift in Sources */,

--- a/App/xcbuddykit/Sources/Generator/BuildPhaseGenerator.swift
+++ b/App/xcbuddykit/Sources/Generator/BuildPhaseGenerator.swift
@@ -1,0 +1,86 @@
+import Basic
+import Foundation
+import xcodeproj
+
+/// Errors thrown during the build phases generation.
+///
+/// - missingFileReference: error thrown when we try to generate a build file for a file whose reference is not in the project.
+enum BuildPhaseGenerationError: Error, ErrorStringConvertible {
+    case missingFileReference(AbsolutePath)
+
+    var errorDescription: String {
+        switch self {
+        case let .missingFileReference(path):
+            return "Trying to add a file at path \(path) to a build phase that hasn't been added to the project."
+        }
+    }
+}
+
+/// Build phase generator interface.
+protocol BuildPhaseGenerating: AnyObject {
+    func generateBuildPhases(targetSpec: Target,
+                             target: PBXTarget,
+                             fileElements: ProjectFileElements,
+                             objects: PBXObjects,
+                             context: GeneratorContexting)
+
+    /// Generates the sources build phase.
+    ///
+    /// - Parameters:
+    ///   - buildPhase: build phase specification.
+    ///   - target: target whose build phase is being generated.
+    ///   - fileElements: file elements instance.
+    ///   - objects: project objects.
+    ///   - context: generation context.
+    func generateSourcesBuildPhase(_ buildPhase: SourcesBuildPhase,
+                                   target: PBXTarget,
+                                   fileElements: ProjectFileElements,
+                                   objects: PBXObjects,
+                                   context: GeneratorContexting)
+}
+
+/// Build phase generator.
+final class BuildPhaseGenerator: BuildPhaseGenerating {
+    func generateBuildPhases(targetSpec: Target,
+                             target: PBXTarget,
+                             fileElements: ProjectFileElements,
+                             objects: PBXObjects,
+                             context: GeneratorContexting) {
+        targetSpec.buildPhases.forEach { buildPhase in
+            if let sourcesBuildPhase = buildPhase as? SourcesBuildPhase {
+                generateSourcesBuildPhase(sourcesBuildPhase,
+                                          target: target,
+                                          fileElements: fileElements,
+                                          objects: objects,
+                                          context: context)
+            }
+        }
+    }
+
+    /// Generates the sources build phase.
+    ///
+    /// - Parameters:
+    ///   - buildPhase: build phase specification.
+    ///   - target: target whose build phase is being generated.
+    ///   - fileElements: file elements instance.
+    ///   - objects: project objects.
+    ///   - context: generation context.
+    func generateSourcesBuildPhase(_ buildPhase: SourcesBuildPhase,
+                                   target: PBXTarget,
+                                   fileElements: ProjectFileElements,
+                                   objects: PBXObjects,
+                                   context: GeneratorContexting) {
+        let sourcesBuildPhase = PBXSourcesBuildPhase()
+        let sourcesBuildPhaseReference = objects.addObject(sourcesBuildPhase)
+        target.buildPhases.append(sourcesBuildPhaseReference)
+        buildPhase.buildFiles.files.forEach { path in
+            guard let fileReference = fileElements.file(path: path) else {
+                context.errorHandler.fatal(error: FatalError.bugSilent(BuildPhaseGenerationError.missingFileReference(path)))
+                return
+            }
+            let buildFile = PBXBuildFile(fileRef: fileReference.reference)
+            let buildFileReference = objects.addObject(buildFile)
+            sourcesBuildPhase.files.append(buildFileReference)
+        }
+    }
+}

--- a/App/xcbuddykit/Sources/Generator/BuildPhaseGenerator.swift
+++ b/App/xcbuddykit/Sources/Generator/BuildPhaseGenerator.swift
@@ -5,13 +5,22 @@ import xcodeproj
 /// Errors thrown during the build phases generation.
 ///
 /// - missingFileReference: error thrown when we try to generate a build file for a file whose reference is not in the project.
-enum BuildPhaseGenerationError: Error, ErrorStringConvertible {
+enum BuildPhaseGenerationError: Error, Equatable, ErrorStringConvertible {
     case missingFileReference(AbsolutePath)
 
     var errorDescription: String {
         switch self {
         case let .missingFileReference(path):
             return "Trying to add a file at path \(path) to a build phase that hasn't been added to the project."
+        }
+    }
+
+    static func == (lhs: BuildPhaseGenerationError, rhs: BuildPhaseGenerationError) -> Bool {
+        switch (lhs, rhs) {
+        case let (.missingFileReference(lhsPath), .missingFileReference(rhsPath)):
+            return lhsPath == rhsPath
+        default:
+            return false
         }
     }
 }

--- a/App/xcbuddykit/Sources/Generator/ProjectGenerator.swift
+++ b/App/xcbuddykit/Sources/Generator/ProjectGenerator.swift
@@ -92,12 +92,13 @@ final class ProjectGenerator: ProjectGenerating {
                                                     context: context,
                                                     options: options)
         try project.targets.forEach { target in
-            try targetGenerator.generateTarget(target: target,
-                                               pbxproj: pbxproj,
-                                               pbxProject: pbxProject,
-                                               groups: groups,
-                                               sourceRootPath: sourceRootPath,
-                                               context: context)
+            targetGenerator.generateTarget(target: target,
+                                           objects: pbxproj.objects,
+                                           pbxProject: pbxProject,
+                                           groups: groups,
+                                           fileElements: fileElements,
+                                           sourceRootPath: sourceRootPath,
+                                           context: context)
         }
 
         /// Write.

--- a/App/xcbuddykit/Tests/Generator/BuildPhaseGeneratorTests.swift
+++ b/App/xcbuddykit/Tests/Generator/BuildPhaseGeneratorTests.swift
@@ -1,0 +1,61 @@
+import Basic
+import Foundation
+@testable import xcbuddykit
+@testable import xcodeproj
+import XCTest
+
+final class BuildPhaseGeneratorTests: XCTestCase {
+    var subject: BuildPhaseGenerator!
+    var errorHandler: MockErrorHandler!
+    var context: GeneratorContext!
+
+    override func setUp() {
+        subject = BuildPhaseGenerator()
+        errorHandler = MockErrorHandler()
+        context = GeneratorContext(graph: Graph.test(), errorHandler: errorHandler)
+    }
+
+    func test_generateSourcesBuildPhase() throws {
+        let path = AbsolutePath("/test/file.swift")
+        let buildFiles = BuildFiles(files: Set([path]))
+        let buildPhaseSpec = SourcesBuildPhase(buildFiles: buildFiles)
+        let target = PBXNativeTarget(name: "Test")
+        let objects = PBXObjects(objects: [:])
+        objects.addObject(target)
+        let fileElements = ProjectFileElements()
+        let fileReference = PBXFileReference(sourceTree: .group, name: "Test")
+        let fileReferenceReference = objects.addObject(fileReference)
+        fileElements.elements[path] = fileReference
+        subject.generateSourcesBuildPhase(buildPhaseSpec,
+                                          target: target,
+                                          fileElements: fileElements,
+                                          objects: objects,
+                                          context: context)
+        let buildPhase: PBXSourcesBuildPhase? = try target.buildPhases.first?.object()
+        XCTAssertNotNil(buildPhase)
+        let buildFile: PBXBuildFile? = try buildPhase?.files.first?.object()
+        XCTAssertNotNil(buildFile)
+        XCTAssertEqual(buildFile?.fileRef, fileReferenceReference)
+    }
+
+    func test_generateSourcesBuildPhase_fatals_when_theFileReferenceIsMissing() {
+        let path = AbsolutePath("/test/file.swift")
+        let buildFiles = BuildFiles(files: Set([path]))
+        let buildPhase = SourcesBuildPhase(buildFiles: buildFiles)
+        let target = PBXNativeTarget(name: "Test")
+        let objects = PBXObjects(objects: [:])
+        objects.addObject(target)
+        let fileElements = ProjectFileElements()
+        subject.generateSourcesBuildPhase(buildPhase,
+                                          target: target,
+                                          fileElements: fileElements,
+                                          objects: objects,
+                                          context: context)
+        let error = errorHandler.fatalErrorArgs.first
+        XCTAssertNotNil(error)
+        XCTAssertTrue(error?.isSilent == true)
+        XCTAssertTrue(error?.isBug == true)
+        let expected = BuildPhaseGenerationError.missingFileReference(path)
+        XCTAssertEqual(error?.bug as? BuildPhaseGenerationError, expected)
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 * Files and groups generation https://github.com/xcbuddy/xcbuddy/pull/28 by @pepibumur.
+* Sources build phase generation https://github.com/xcbuddy/xcbuddy/pull/30 by @pepibumur.
 
 ## 0.34.0
 


### PR DESCRIPTION
### Short description 📝
Adds a new generator to generate build phases. This PR only includes the generation of the sources build phase.

### Solution 📦
- [x] Define `BuildPhaseGenerating` protocol.
- [x] Implement `BuildPhaseGenerator`.
- [x] Use it from the target generator.
- [x] Unit tests.