### PR TITLE
Add convenience API to Graph

### DIFF
--- a/App.xcodeproj/project.pbxproj
+++ b/App.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		B9589609208B4E8E00F00ACF /* MockProjectGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9589608208B4E8E00F00ACF /* MockProjectGenerator.swift */; };
 		B958960B208B578700F00ACF /* GraphCircularDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958960A208B578700F00ACF /* GraphCircularDetector.swift */; };
 		B958960D208B607400F00ACF /* GraphCircularDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958960C208B607400F00ACF /* GraphCircularDetectorTests.swift */; };
+		B97DDE9C20B448250052EB48 /* GraphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97DDE9B20B448250052EB48 /* GraphTests.swift */; };
 		B9B593C5209C121000C59DA2 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9B593C4209C121000C59DA2 /* Sentry.framework */; };
 		B9B593C7209C13BE00C59DA2 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B593C6209C13BE00C59DA2 /* ErrorHandler.swift */; };
 		B9B593C8209C13CB00C59DA2 /* Sentry.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B9B593C4209C121000C59DA2 /* Sentry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -304,6 +305,7 @@
 		B9589608208B4E8E00F00ACF /* MockProjectGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProjectGenerator.swift; sourceTree = "<group>"; };
 		B958960A208B578700F00ACF /* GraphCircularDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCircularDetector.swift; sourceTree = "<group>"; };
 		B958960C208B607400F00ACF /* GraphCircularDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCircularDetectorTests.swift; sourceTree = "<group>"; };
+		B97DDE9B20B448250052EB48 /* GraphTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphTests.swift; sourceTree = "<group>"; };
 		B9B593C4209C121000C59DA2 /* Sentry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Sentry.framework; sourceTree = "<group>"; };
 		B9B593C6209C13BE00C59DA2 /* ErrorHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorHandler.swift; sourceTree = "<group>"; };
 		B9B59439209C176600C59DA2 /* ErrorHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorHandlerTests.swift; sourceTree = "<group>"; };
@@ -592,6 +594,7 @@
 				B958960C208B607400F00ACF /* GraphCircularDetectorTests.swift */,
 				B9F1EDD4208D080C00477835 /* GraphManifestLoaderTests.swift */,
 				B9553DEB2090F62C00050311 /* GraphNodeTests.swift */,
+				B97DDE9B20B448250052EB48 /* GraphTests.swift */,
 			);
 			path = Loader;
 			sourceTree = "<group>";
@@ -1168,6 +1171,7 @@
 				B9F1EDD5208D080C00477835 /* GraphManifestLoaderTests.swift in Sources */,
 				B9E2DCC62088F0970061DF86 /* MockCommand.swift in Sources */,
 				3D92B79120A82A82006711E5 /* Graph+TestData.swift in Sources */,
+				B97DDE9C20B448250052EB48 /* GraphTests.swift in Sources */,
 				B9E2DC9420872B190061DF86 /* BuildConfigurationTests.swift in Sources */,
 				B9F1EDED208D1CFE00477835 /* Target+TestData.swift in Sources */,
 				3D92B77B20A818CD006711E5 /* CommandCheckTests.swift in Sources */,

--- a/App/xcbuddykit/Sources/Loader/Graph.swift
+++ b/App/xcbuddykit/Sources/Loader/Graph.swift
@@ -8,6 +8,9 @@ protocol Graphing: AnyObject {
     var cache: GraphLoaderCaching { get }
     var entryNodes: [GraphNode] { get }
     var projects: [Project] { get }
+    func linkableDependencies(path: AbsolutePath, name: String) -> [AbsolutePath]
+    func dependenciesPublicHeaders(path: AbsolutePath, name: String) -> [AbsolutePath]
+    func embeddableFrameworks(path: AbsolutePath, name: String, shell: Shelling) throws -> [AbsolutePath]
 }
 
 /// Graph representation.
@@ -29,6 +32,13 @@ class Graph: Graphing {
         return Array(cache.projects.values)
     }
 
+    /// Initializes the graph with its attributes.
+    ///
+    /// - Parameters:
+    ///   - name: graph name.
+    ///   - entryPath: path to the folder that contains the entry point manifest.
+    ///   - cache: graph cache.
+    ///   - entryNodes: nodes that are defined in the entry point manifest.
     init(name: String,
          entryPath: AbsolutePath,
          cache: GraphLoaderCaching,
@@ -37,5 +47,56 @@ class Graph: Graphing {
         self.entryPath = entryPath
         self.cache = cache
         self.entryNodes = entryNodes
+    }
+
+    /// Given a target, it returns the list of dependencies that should be linked from it.
+    ///
+    /// - Parameters:
+    ///   - path: path to the folder that contains the manifest where the target is defined.
+    ///   - name: target name.
+    /// - Returns: paths to the linkable dependencies (.framework & .a)
+    func linkableDependencies(path: AbsolutePath, name: String) -> [AbsolutePath] {
+        guard let targetNodes = cache.targetNodes[path] else { return [] }
+        guard let targetNode = targetNodes[name] else { return [] }
+        return targetNode
+            .dependencies
+            .compactMap({ $0 as? PrecompiledNode })
+            .map({ $0.path })
+    }
+
+    /// Given a target, it returns the list of public headers folders that should be
+    /// exposed to the target.
+    ///
+    /// - Parameters:
+    ///   - path: path to the folder that contains the manifest where the target is defined.
+    ///   - name: target name.
+    /// - Returns: paths to the public headers folders.
+    func dependenciesPublicHeaders(path: AbsolutePath, name: String) -> [AbsolutePath] {
+        guard let targetNodes = cache.targetNodes[path] else { return [] }
+        guard let targetNode = targetNodes[name] else { return [] }
+        return targetNode
+            .dependencies
+            .compactMap({ $0 as? LibraryNode })
+            .map({ $0.publicHeaders })
+    }
+
+    /// Given a target, it returns the list of frameworks that should be embedded into the
+    /// frameworks folder of the target product.
+    ///
+    /// - Parameters:
+    ///   - path: path to the folder that contains the manifest where the target is defined.
+    ///   - name: target name.
+    ///   - shell: shell util.
+    /// - Returns: paths to the frameworks that should be embedded.
+    /// - Throws: an error is thrown while trying to get whether a framework is static or dynamic.
+    func embeddableFrameworks(path: AbsolutePath, name: String, shell: Shelling) throws -> [AbsolutePath] {
+        guard let targetNodes = cache.targetNodes[path] else { return [] }
+        guard let targetNode = targetNodes[name] else { return [] }
+        if targetNode.target.product != .app { return [] }
+        return try targetNode
+            .dependencies
+            .compactMap({ $0 as? FrameworkNode })
+            .filter({ try $0.linking(shell: shell) == .dynamic })
+            .map({ $0.path })
     }
 }

--- a/App/xcbuddykit/Sources/Loader/Graph.swift
+++ b/App/xcbuddykit/Sources/Loader/Graph.swift
@@ -1,6 +1,55 @@
 import Basic
 import Foundation
 
+/// Graph error.
+///
+/// - unsupportedFileExtension: thrown when the file extension cannot be obtained for the given product.
+enum GraphError: FatalError {
+    case unsupportedFileExtension(String)
+
+    /// Error description.
+    var description: String {
+        switch self {
+        case let .unsupportedFileExtension(productType):
+            return "Could't obtain product file extension for product type: \(productType)"
+        }
+    }
+
+    /// Error type
+    var type: ErrorType {
+        switch self {
+        case .unsupportedFileExtension:
+            return .bugSilent
+        }
+    }
+}
+
+/// Dependency reference.
+///
+/// - absolute: the reference is an absolute path to the dependency.
+/// - product: the reference is the name of it in the products directory.
+enum DependencyReference: Equatable {
+    case absolute(AbsolutePath)
+    case product(String)
+
+    /// Returns true if two instances of DependencyReference are equal.
+    ///
+    /// - Parameters:
+    ///   - lhs: first instance to be compared.
+    ///   - rhs: second instance to be compared.
+    /// - Returns: true if the two instances are the same.
+    static func == (lhs: DependencyReference, rhs: DependencyReference) -> Bool {
+        switch (lhs, rhs) {
+        case let (.absolute(lhsPath), .absolute(rhsPath)):
+            return lhsPath == rhsPath
+        case let (.product(lhsName), .product(rhsName)):
+            return lhsName == rhsName
+        default:
+            return false
+        }
+    }
+}
+
 /// Protocol that represents a graph.
 protocol Graphing: AnyObject {
     var name: String { get }
@@ -8,9 +57,9 @@ protocol Graphing: AnyObject {
     var cache: GraphLoaderCaching { get }
     var entryNodes: [GraphNode] { get }
     var projects: [Project] { get }
-    func linkableDependencies(path: AbsolutePath, name: String) -> [AbsolutePath]
-    func dependenciesPublicHeaders(path: AbsolutePath, name: String) -> [AbsolutePath]
-    func embeddableFrameworks(path: AbsolutePath, name: String, shell: Shelling) throws -> [AbsolutePath]
+    func linkableDependencies(path: AbsolutePath, name: String) throws -> [DependencyReference]
+    func librariesPublicHeaders(path: AbsolutePath, name: String) -> [AbsolutePath]
+    func embeddableFrameworks(path: AbsolutePath, name: String, shell: Shelling) throws -> [DependencyReference]
 }
 
 /// Graph representation.
@@ -55,13 +104,32 @@ class Graph: Graphing {
     ///   - path: path to the folder that contains the manifest where the target is defined.
     ///   - name: target name.
     /// - Returns: paths to the linkable dependencies (.framework & .a)
-    func linkableDependencies(path: AbsolutePath, name: String) -> [AbsolutePath] {
+    func linkableDependencies(path: AbsolutePath, name: String) throws -> [DependencyReference] {
         guard let targetNodes = cache.targetNodes[path] else { return [] }
         guard let targetNode = targetNodes[name] else { return [] }
-        return targetNode
+
+        var references: [DependencyReference] = []
+
+        /// Precompiled libraries and frameworks
+        references.append(contentsOf: targetNode
             .dependencies
             .compactMap({ $0 as? PrecompiledNode })
-            .map({ $0.path })
+            .map({ DependencyReference.absolute($0.path) }))
+
+        /// Other targets frameworks and libraries
+        try references.append(contentsOf: targetNode
+            .dependencies
+            .compactMap({ $0 as? TargetNode })
+            .filter({ $0.target.isLinkable() })
+            .map({ targetNode in
+                let xcodeProduct = targetNode.target.product.xcodeValue
+                guard let `extension` = xcodeProduct.fileExtension else {
+                    throw GraphError.unsupportedFileExtension(xcodeProduct.rawValue)
+                }
+                return DependencyReference.product("\(targetNode.target.name).\(`extension`)")
+        }))
+
+        return references
     }
 
     /// Given a target, it returns the list of public headers folders that should be
@@ -71,7 +139,7 @@ class Graph: Graphing {
     ///   - path: path to the folder that contains the manifest where the target is defined.
     ///   - name: target name.
     /// - Returns: paths to the public headers folders.
-    func dependenciesPublicHeaders(path: AbsolutePath, name: String) -> [AbsolutePath] {
+    func librariesPublicHeaders(path: AbsolutePath, name: String) -> [AbsolutePath] {
         guard let targetNodes = cache.targetNodes[path] else { return [] }
         guard let targetNode = targetNodes[name] else { return [] }
         return targetNode
@@ -89,14 +157,36 @@ class Graph: Graphing {
     ///   - shell: shell util.
     /// - Returns: paths to the frameworks that should be embedded.
     /// - Throws: an error is thrown while trying to get whether a framework is static or dynamic.
-    func embeddableFrameworks(path: AbsolutePath, name: String, shell: Shelling) throws -> [AbsolutePath] {
+    func embeddableFrameworks(path: AbsolutePath,
+                              name: String,
+                              shell: Shelling) throws -> [DependencyReference] {
         guard let targetNodes = cache.targetNodes[path] else { return [] }
         guard let targetNode = targetNodes[name] else { return [] }
+
+        /// If the target is not an app we shouldn't embed anything.
         if targetNode.target.product != .app { return [] }
-        return try targetNode
+
+        var references: [DependencyReference] = []
+
+        /// Precompiled frameworks
+        references.append(contentsOf: try targetNode
             .dependencies
             .compactMap({ $0 as? FrameworkNode })
             .filter({ try $0.linking(shell: shell) == .dynamic })
-            .map({ $0.path })
+            .map({ DependencyReference.absolute($0.path) }))
+
+        /// Other targets' frameworks.
+        try references.append(contentsOf: targetNode
+            .dependencies
+            .compactMap({ $0 as? TargetNode })
+            .filter({ $0.target.product == .framework })
+            .map({ targetNode in
+                let xcodeProduct = targetNode.target.product.xcodeValue
+                guard let `extension` = xcodeProduct.fileExtension else {
+                    throw GraphError.unsupportedFileExtension(xcodeProduct.rawValue)
+                }
+                return DependencyReference.product("\(targetNode.target.name).\(`extension`)")
+        }))
+        return references
     }
 }

--- a/App/xcbuddykit/Sources/Models/Target.swift
+++ b/App/xcbuddykit/Sources/Models/Target.swift
@@ -95,6 +95,13 @@ class Target: GraphJSONInitiatable, Equatable {
         dependencies = try json.get("dependencies")
     }
 
+    /// Returns true if the target can be linked.
+    ///
+    /// - Returns: true if the target can be linked.
+    func isLinkable() -> Bool {
+        return product == .dynamicLibrary || product == .staticLibrary || product == .framework
+    }
+
     /// Compares two targets.
     ///
     /// - Parameters:

--- a/App/xcbuddykit/Tests/Loader/GraphTests.swift
+++ b/App/xcbuddykit/Tests/Loader/GraphTests.swift
@@ -1,0 +1,135 @@
+import Basic
+import Foundation
+@testable import xcbuddykit
+import XCTest
+
+final class GraphTests: XCTestCase {
+    func test_linkableDependencies_whenPrecompiled() throws {
+        let target = Target.test(name: "Main")
+        let precompiledNode = FrameworkNode(path: AbsolutePath("/test/test.framework"))
+        let project = Project.test(targets: [target])
+        let targetNode = TargetNode(project: project,
+                                    target: target,
+                                    dependencies: [precompiledNode])
+        let cache = GraphLoaderCache()
+        cache.add(targetNode: targetNode)
+        let graph = Graph.test(cache: cache)
+        let got = try graph.linkableDependencies(path: project.path,
+                                                 name: target.name)
+        XCTAssertEqual(got.first, .absolute(precompiledNode.path))
+    }
+
+    func test_linkableDependencies_whenALibraryTarget() throws {
+        let target = Target.test(name: "Main")
+        let dependency = Target.test(name: "Dependency", product: .staticLibrary)
+        let project = Project.test(targets: [target])
+        let dependencyNode = TargetNode(project: project,
+                                        target: dependency,
+                                        dependencies: [])
+        let targetNode = TargetNode(project: project,
+                                    target: target,
+                                    dependencies: [dependencyNode])
+        let cache = GraphLoaderCache()
+        cache.add(targetNode: targetNode)
+        let graph = Graph.test(cache: cache)
+        let got = try graph.linkableDependencies(path: project.path,
+                                                 name: target.name)
+        XCTAssertEqual(got.first, .product("Dependency.a"))
+    }
+
+    func test_linkableDependencies_whenAFrameworkTarget() throws {
+        let target = Target.test(name: "Main")
+        let dependency = Target.test(name: "Dependency", product: .framework)
+        let project = Project.test(targets: [target])
+        let dependencyNode = TargetNode(project: project,
+                                        target: dependency,
+                                        dependencies: [])
+        let targetNode = TargetNode(project: project,
+                                    target: target,
+                                    dependencies: [dependencyNode])
+        let cache = GraphLoaderCache()
+        cache.add(targetNode: targetNode)
+        let graph = Graph.test(cache: cache)
+        let got = try graph.linkableDependencies(path: project.path,
+                                                 name: target.name)
+        XCTAssertEqual(got.first, .product("Dependency.framework"))
+    }
+
+    func test_librariesPublicHeaders() throws {
+        let target = Target.test(name: "Main")
+        let publicHeadersPath = AbsolutePath("/test/public/")
+        let precompiledNode = LibraryNode(path: AbsolutePath("/test/test.a"),
+                                          publicHeaders: publicHeadersPath)
+        let project = Project.test(targets: [target])
+        let targetNode = TargetNode(project: project,
+                                    target: target,
+                                    dependencies: [precompiledNode])
+        let cache = GraphLoaderCache()
+        cache.add(targetNode: targetNode)
+        let graph = Graph.test(cache: cache)
+        let got = graph.librariesPublicHeaders(path: project.path,
+                                               name: target.name)
+        XCTAssertEqual(got.first, publicHeadersPath)
+    }
+    
+    func test_embeddableFrameworks_when_targetIsNotApp() throws {
+        let target = Target.test(name: "Main", product: .framework)
+        let dependency = Target.test(name: "Dependency", product: .framework)
+        let project = Project.test(targets: [target])
+        let dependencyNode = TargetNode(project: project,
+                                        target: dependency,
+                                        dependencies: [])
+        let targetNode = TargetNode(project: project,
+                                    target: target,
+                                    dependencies: [dependencyNode])
+        let cache = GraphLoaderCache()
+        cache.add(targetNode: targetNode)
+        let graph = Graph.test(cache: cache)
+        let shell = MockShell()
+        shell.runStub = { _ in "dynamically linked" }
+        let got = try graph.embeddableFrameworks(path: project.path,
+                                                 name: target.name,
+                                                 shell: shell)
+        XCTAssertNil(got.first)
+    }
+
+    func test_embeddableFrameworks_when_dependencyIsATarget() throws {
+        let target = Target.test(name: "Main")
+        let dependency = Target.test(name: "Dependency", product: .framework)
+        let project = Project.test(targets: [target])
+        let dependencyNode = TargetNode(project: project,
+                                        target: dependency,
+                                        dependencies: [])
+        let targetNode = TargetNode(project: project,
+                                    target: target,
+                                    dependencies: [dependencyNode])
+        let cache = GraphLoaderCache()
+        cache.add(targetNode: targetNode)
+        let graph = Graph.test(cache: cache)
+        let shell = MockShell()
+        shell.runStub = { _ in "dynamically linked" }
+        let got = try graph.embeddableFrameworks(path: project.path,
+                                                 name: target.name,
+                                                 shell: shell)
+        XCTAssertEqual(got.first, DependencyReference.product("Dependency.framework"))
+    }
+
+    func test_embeddableFrameworks_when_dependencyIsAFramework() throws {
+        let frameworkPath = AbsolutePath("/test/test.framework")
+        let target = Target.test(name: "Main")
+        let frameworkNode = FrameworkNode(path: frameworkPath)
+        let project = Project.test(targets: [target])
+        let targetNode = TargetNode(project: project,
+                                    target: target,
+                                    dependencies: [frameworkNode])
+        let cache = GraphLoaderCache()
+        cache.add(targetNode: targetNode)
+        let graph = Graph.test(cache: cache)
+        let shell = MockShell()
+        shell.runStub = { _ in "dynamically linked" }
+        let got = try graph.embeddableFrameworks(path: project.path,
+                                                 name: target.name,
+                                                 shell: shell)
+        XCTAssertEqual(got.first, DependencyReference.absolute(frameworkPath))
+    }
+}

--- a/App/xcbuddykit/Tests/Loader/GraphTests.swift
+++ b/App/xcbuddykit/Tests/Loader/GraphTests.swift
@@ -3,6 +3,19 @@ import Foundation
 @testable import xcbuddykit
 import XCTest
 
+final class GraphErrorTests: XCTestCase {
+    func test_description_when_unsupportedFileExtension() {
+        let error = GraphError.unsupportedFileExtension("type")
+        let description = "Could't obtain product file extension for product type: type"
+        XCTAssertEqual(error.description, description)
+    }
+    
+    func test_type_when_unsupportedFileExtension() {
+        let error = GraphError.unsupportedFileExtension("type")
+        XCTAssertEqual(error.type, .bugSilent)
+    }
+}
+
 final class GraphTests: XCTestCase {
     func test_linkableDependencies_whenPrecompiled() throws {
         let target = Target.test(name: "Main")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 * Sources build phase generation https://github.com/xcbuddy/xcbuddy/pull/30 by @pepibumur.
 * Add `create-issue` command https://github.com/xcbuddy/xcbuddy/pull/32 by @pepibumur.
 * Add support for variant groups https://github.com/xcbuddy/xcbuddy/pull/34 by @pepibumur.
+* Convenience API to `Graph` https://github.com/xcbuddy/xcbuddy/pull/35 by @pepibumur.
 
 ### Changed
 


### PR DESCRIPTION
### Short description 📝
This PR adds an API to `Graph` to:
- Get linkable frameworks and libraries for a given.
- Get embeddable frameworks for any given target.
- Get public headers that should be exposed to a given target.

```swift
func linkableDependencies(path: AbsolutePath, name: String) throws -> [DependencyReference]
func librariesPublicHeaders(path: AbsolutePath, name: String) -> [AbsolutePath]
func embeddableFrameworks(path: AbsolutePath, name: String, shell: Shelling) throws -> [DependencyReference]
```