### PR TITLE
Module loader

### DIFF
--- a/App.xcodeproj/project.pbxproj
+++ b/App.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		B958960B208B578700F00ACF /* GraphCircularDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958960A208B578700F00ACF /* GraphCircularDetector.swift */; };
 		B958960D208B607400F00ACF /* GraphCircularDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958960C208B607400F00ACF /* GraphCircularDetectorTests.swift */; };
 		B97DDE9C20B448250052EB48 /* GraphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97DDE9B20B448250052EB48 /* GraphTests.swift */; };
+		B99D5D4420B5C8A400249856 /* GraphModuleLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99D5D4320B5C8A400249856 /* GraphModuleLoader.swift */; };
 		B9B593C5209C121000C59DA2 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9B593C4209C121000C59DA2 /* Sentry.framework */; };
 		B9B593C7209C13BE00C59DA2 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B593C6209C13BE00C59DA2 /* ErrorHandler.swift */; };
 		B9B593C8209C13CB00C59DA2 /* Sentry.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B9B593C4209C121000C59DA2 /* Sentry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -308,6 +309,7 @@
 		B958960A208B578700F00ACF /* GraphCircularDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCircularDetector.swift; sourceTree = "<group>"; };
 		B958960C208B607400F00ACF /* GraphCircularDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCircularDetectorTests.swift; sourceTree = "<group>"; };
 		B97DDE9B20B448250052EB48 /* GraphTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphTests.swift; sourceTree = "<group>"; };
+		B99D5D4320B5C8A400249856 /* GraphModuleLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphModuleLoader.swift; sourceTree = "<group>"; };
 		B9B593C4209C121000C59DA2 /* Sentry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Sentry.framework; sourceTree = "<group>"; };
 		B9B593C6209C13BE00C59DA2 /* ErrorHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorHandler.swift; sourceTree = "<group>"; };
 		B9B59439209C176600C59DA2 /* ErrorHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorHandlerTests.swift; sourceTree = "<group>"; };
@@ -840,6 +842,7 @@
 				B9FB2DD42086538E00BC2FB3 /* GraphLoaderCache.swift */,
 				B95895FE208A37B300F00ACF /* GraphJSONInitiatable.swift */,
 				B958960A208B578700F00ACF /* GraphCircularDetector.swift */,
+				B99D5D4320B5C8A400249856 /* GraphModuleLoader.swift */,
 			);
 			path = Loader;
 			sourceTree = "<group>";
@@ -1131,6 +1134,7 @@
 				B9E2DCAA208774550061DF86 /* CommandRegistry.swift in Sources */,
 				B95895F9208A2B7C00F00ACF /* TargetGenerator.swift in Sources */,
 				B9B593C7209C13BE00C59DA2 /* ErrorHandler.swift in Sources */,
+				B99D5D4420B5C8A400249856 /* GraphModuleLoader.swift in Sources */,
 				B9B629AB20864E3A00EE9E07 /* Printer.swift in Sources */,
 				B92122BD20AF372F009C4691 /* CreateIssueCommand.swift in Sources */,
 				B95895F5208A2ADB00F00ACF /* GeneratorContext.swift in Sources */,

--- a/App.xcodeproj/project.pbxproj
+++ b/App.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		B97DDE9C20B448250052EB48 /* GraphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97DDE9B20B448250052EB48 /* GraphTests.swift */; };
 		B99D5D4420B5C8A400249856 /* GraphModuleLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99D5D4320B5C8A400249856 /* GraphModuleLoader.swift */; };
 		B99D5D4620B6878400249856 /* MockGraphModuleLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99D5D4520B6878400249856 /* MockGraphModuleLoader.swift */; };
+		B99D5D4820B6C87B00249856 /* GraphModuleLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99D5D4720B6C87B00249856 /* GraphModuleLoaderTests.swift */; };
 		B9B593C5209C121000C59DA2 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9B593C4209C121000C59DA2 /* Sentry.framework */; };
 		B9B593C7209C13BE00C59DA2 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B593C6209C13BE00C59DA2 /* ErrorHandler.swift */; };
 		B9B593C8209C13CB00C59DA2 /* Sentry.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B9B593C4209C121000C59DA2 /* Sentry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -312,6 +313,7 @@
 		B97DDE9B20B448250052EB48 /* GraphTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphTests.swift; sourceTree = "<group>"; };
 		B99D5D4320B5C8A400249856 /* GraphModuleLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphModuleLoader.swift; sourceTree = "<group>"; };
 		B99D5D4520B6878400249856 /* MockGraphModuleLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGraphModuleLoader.swift; sourceTree = "<group>"; };
+		B99D5D4720B6C87B00249856 /* GraphModuleLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphModuleLoaderTests.swift; sourceTree = "<group>"; };
 		B9B593C4209C121000C59DA2 /* Sentry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Sentry.framework; sourceTree = "<group>"; };
 		B9B593C6209C13BE00C59DA2 /* ErrorHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorHandler.swift; sourceTree = "<group>"; };
 		B9B59439209C176600C59DA2 /* ErrorHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorHandlerTests.swift; sourceTree = "<group>"; };
@@ -602,6 +604,7 @@
 				B9F1EDD4208D080C00477835 /* GraphManifestLoaderTests.swift */,
 				B9553DEB2090F62C00050311 /* GraphNodeTests.swift */,
 				B97DDE9B20B448250052EB48 /* GraphTests.swift */,
+				B99D5D4720B6C87B00249856 /* GraphModuleLoaderTests.swift */,
 			);
 			path = Loader;
 			sourceTree = "<group>";
@@ -1201,6 +1204,7 @@
 				B9E2DC9920872C0F0061DF86 /* MockFileHandler.swift in Sources */,
 				B9589609208B4E8E00F00ACF /* MockProjectGenerator.swift in Sources */,
 				B99D5D4620B6878400249856 /* MockGraphModuleLoader.swift in Sources */,
+				B99D5D4820B6C87B00249856 /* GraphModuleLoaderTests.swift in Sources */,
 				B9E2DC9F20872D450061DF86 /* MockLogger.swift in Sources */,
 				3D92B7E720A84888006711E5 /* ProjectGroupsTests.swift in Sources */,
 				3D92B78020A823FF006711E5 /* NSError+TestData.swift in Sources */,

--- a/App.xcodeproj/project.pbxproj
+++ b/App.xcodeproj/project.pbxproj
@@ -72,6 +72,8 @@
 		B99D5D4420B5C8A400249856 /* GraphModuleLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99D5D4320B5C8A400249856 /* GraphModuleLoader.swift */; };
 		B99D5D4620B6878400249856 /* MockGraphModuleLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99D5D4520B6878400249856 /* MockGraphModuleLoader.swift */; };
 		B99D5D4820B6C87B00249856 /* GraphModuleLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99D5D4720B6C87B00249856 /* GraphModuleLoaderTests.swift */; };
+		B99D5D4A20B847FC00249856 /* FileAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99D5D4920B847FC00249856 /* FileAggregator.swift */; };
+		B99D5D4C20B85A1400249856 /* FileAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99D5D4B20B85A1400249856 /* FileAggregatorTests.swift */; };
 		B9B593C5209C121000C59DA2 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9B593C4209C121000C59DA2 /* Sentry.framework */; };
 		B9B593C7209C13BE00C59DA2 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B593C6209C13BE00C59DA2 /* ErrorHandler.swift */; };
 		B9B593C8209C13CB00C59DA2 /* Sentry.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B9B593C4209C121000C59DA2 /* Sentry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -314,6 +316,8 @@
 		B99D5D4320B5C8A400249856 /* GraphModuleLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphModuleLoader.swift; sourceTree = "<group>"; };
 		B99D5D4520B6878400249856 /* MockGraphModuleLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGraphModuleLoader.swift; sourceTree = "<group>"; };
 		B99D5D4720B6C87B00249856 /* GraphModuleLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphModuleLoaderTests.swift; sourceTree = "<group>"; };
+		B99D5D4920B847FC00249856 /* FileAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileAggregator.swift; sourceTree = "<group>"; };
+		B99D5D4B20B85A1400249856 /* FileAggregatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileAggregatorTests.swift; sourceTree = "<group>"; };
 		B9B593C4209C121000C59DA2 /* Sentry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Sentry.framework; sourceTree = "<group>"; };
 		B9B593C6209C13BE00C59DA2 /* ErrorHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorHandler.swift; sourceTree = "<group>"; };
 		B9B59439209C176600C59DA2 /* ErrorHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorHandlerTests.swift; sourceTree = "<group>"; };
@@ -744,6 +748,7 @@
 				B9553DF02092181500050311 /* Context.swift */,
 				B9553DF220921AF300050311 /* ResourceLocator.swift */,
 				3D4C0BA120A6ED37003D09B0 /* CommandCheck.swift */,
+				B99D5D4920B847FC00249856 /* FileAggregator.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -866,6 +871,7 @@
 			children = (
 				3D92B77E20A821AA006711E5 /* Mocks */,
 				3D4C0BA320A81828003D09B0 /* CommandCheckTests.swift */,
+				B99D5D4B20B85A1400249856 /* FileAggregatorTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1102,6 +1108,7 @@
 			files = (
 				B9B629AC20864E3A00EE9E07 /* FileHandler.swift in Sources */,
 				B9553DEA2090690000050311 /* Shell.swift in Sources */,
+				B99D5D4A20B847FC00249856 /* FileAggregator.swift in Sources */,
 				B9F1EE00208E2D7F00477835 /* FatalError.swift in Sources */,
 				B95895F3208A2ACF00F00ACF /* ProjectGenerator.swift in Sources */,
 				B9FB2DE52086544900BC2FB3 /* Workspace.swift in Sources */,
@@ -1210,6 +1217,7 @@
 				3D92B78020A823FF006711E5 /* NSError+TestData.swift in Sources */,
 				B9157D5320A24B4300C2EEBA /* VersionCommandTests.swift in Sources */,
 				B9F1EDD1208CD18100477835 /* AargumentParser+TestData.swift in Sources */,
+				B99D5D4C20B85A1400249856 /* FileAggregatorTests.swift in Sources */,
 				B9E2DCBB2088E0B50061DF86 /* UpdateCommandTests.swift in Sources */,
 				B9553DEC2090F62C00050311 /* GraphNodeTests.swift in Sources */,
 				66F6DC2FC19AB1F6D332D8E8 /* ArgumentParserResult+TestData.swift in Sources */,

--- a/App.xcodeproj/project.pbxproj
+++ b/App.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		B958960D208B607400F00ACF /* GraphCircularDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958960C208B607400F00ACF /* GraphCircularDetectorTests.swift */; };
 		B97DDE9C20B448250052EB48 /* GraphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97DDE9B20B448250052EB48 /* GraphTests.swift */; };
 		B99D5D4420B5C8A400249856 /* GraphModuleLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99D5D4320B5C8A400249856 /* GraphModuleLoader.swift */; };
+		B99D5D4620B6878400249856 /* MockGraphModuleLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99D5D4520B6878400249856 /* MockGraphModuleLoader.swift */; };
 		B9B593C5209C121000C59DA2 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9B593C4209C121000C59DA2 /* Sentry.framework */; };
 		B9B593C7209C13BE00C59DA2 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B593C6209C13BE00C59DA2 /* ErrorHandler.swift */; };
 		B9B593C8209C13CB00C59DA2 /* Sentry.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B9B593C4209C121000C59DA2 /* Sentry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -310,6 +311,7 @@
 		B958960C208B607400F00ACF /* GraphCircularDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCircularDetectorTests.swift; sourceTree = "<group>"; };
 		B97DDE9B20B448250052EB48 /* GraphTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphTests.swift; sourceTree = "<group>"; };
 		B99D5D4320B5C8A400249856 /* GraphModuleLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphModuleLoader.swift; sourceTree = "<group>"; };
+		B99D5D4520B6878400249856 /* MockGraphModuleLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGraphModuleLoader.swift; sourceTree = "<group>"; };
 		B9B593C4209C121000C59DA2 /* Sentry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Sentry.framework; sourceTree = "<group>"; };
 		B9B593C6209C13BE00C59DA2 /* ErrorHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorHandler.swift; sourceTree = "<group>"; };
 		B9B59439209C176600C59DA2 /* ErrorHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorHandlerTests.swift; sourceTree = "<group>"; };
@@ -454,6 +456,7 @@
 				B92BF9F0207559E600EE4EBD /* MockGraphLoaderCache.swift */,
 				B92BF9F620755B8500EE4EBD /* MockManifestLoader.swift */,
 				3D92B80620AABE55006711E5 /* MockGraphLoader.swift */,
+				B99D5D4520B6878400249856 /* MockGraphModuleLoader.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1197,6 +1200,7 @@
 				3D7E6CE120AECC9B00360C02 /* BuildPhaseGeneratorTests.swift in Sources */,
 				B9E2DC9920872C0F0061DF86 /* MockFileHandler.swift in Sources */,
 				B9589609208B4E8E00F00ACF /* MockProjectGenerator.swift in Sources */,
+				B99D5D4620B6878400249856 /* MockGraphModuleLoader.swift in Sources */,
 				B9E2DC9F20872D450061DF86 /* MockLogger.swift in Sources */,
 				3D92B7E720A84888006711E5 /* ProjectGroupsTests.swift in Sources */,
 				3D92B78020A823FF006711E5 /* NSError+TestData.swift in Sources */,

--- a/App.xcodeproj/xcshareddata/xcschemes/xcbuddy-cli.xcscheme
+++ b/App.xcodeproj/xcshareddata/xcschemes/xcbuddy-cli.xcscheme
@@ -63,7 +63,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "generate -p /Users/pepibumur/Desktop/Test"
+            argument = "generate -p /Users/pedropinera/Desktop/Test"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/App/xcbuddykit/Sources/Commands/CreateIssueCommand.swift
+++ b/App/xcbuddykit/Sources/Commands/CreateIssueCommand.swift
@@ -37,6 +37,6 @@ public class CreateIssueCommand: NSObject, Command {
     /// - Parameter arguments: input arguments.
     /// - Throws: throws an error if the execution fails.
     public func run(with _: ArgumentParser.Result) throws {
-        _ = try context.shell.run("open", CreateIssueCommand.createIssueUrl)
+        _ = try context.shell.run("open", CreateIssueCommand.createIssueUrl, environment: [:])
     }
 }

--- a/App/xcbuddykit/Sources/Loader/GraphManifestLoader.swift
+++ b/App/xcbuddykit/Sources/Loader/GraphManifestLoader.swift
@@ -12,12 +12,10 @@ protocol GraphManifestLoading {
 ///
 /// - projectDescriptionNotFound: error thrown when the ProjectDescription.framework cannot be cound.
 /// - frameworksFolderNotFound: error thrown when the frameworks fodler that contains the ProjectDescription.framework cannot be found.
-/// - swiftNotFound: error thrown when Swift is not found in the system.
 /// - unexpectedOutput: error throw when we get an unexpected output trying to compile the manifest.
 enum GraphManifestLoaderError: FatalError {
     case projectDescriptionNotFound(AbsolutePath)
     case frameworksFolderNotFound
-    case swiftNotFound
     case unexpectedOutput(AbsolutePath)
 
     /// Error description.
@@ -27,8 +25,6 @@ enum GraphManifestLoaderError: FatalError {
             return "Couldn't find ProjectDescription.framework at path \(path.asString)."
         case .frameworksFolderNotFound:
             return "Couldn't find the Frameworks folder in the bundle that contains the ProjectDescription.framework."
-        case .swiftNotFound:
-            return "Couldn't find Swift on your environment. Run 'xcode-select -p' to see if the Xcode path is properly setup."
         case let .unexpectedOutput(path):
             return "Unexpected output trying to parse the manifest at path \(path.asString)."
         }
@@ -55,7 +51,6 @@ enum GraphManifestLoaderError: FatalError {
         case let (.projectDescriptionNotFound(lhsPath), .projectDescriptionNotFound(rhsPath)):
             return lhsPath == rhsPath
         case (.frameworksFolderNotFound, .frameworksFolderNotFound): return true
-        case (.swiftNotFound, .swiftNotFound): return true
         case let (.unexpectedOutput(lhsPath), .unexpectedOutput(rhsPath)):
             return lhsPath == rhsPath
         default:
@@ -66,6 +61,16 @@ enum GraphManifestLoaderError: FatalError {
 
 /// Graph manifest loader.
 class GraphManifestLoader: GraphManifestLoading {
+    /// Module loader.
+    let moduleLoader: GraphModuleLoading
+
+    /// Initializes the loader with its attributes.
+    ///
+    /// - Parameter moduleLoader: module loader.
+    init(moduleLoader: GraphModuleLoading = GraphModuleLoader()) {
+        self.moduleLoader = moduleLoader
+    }
+
     /// Loads the manifest at the given path.
     ///
     /// - Parameters:
@@ -74,15 +79,16 @@ class GraphManifestLoader: GraphManifestLoading {
     /// - Returns: jSON representation of the manifest.
     /// - Throws: an error if the manifest cannot be loaded.
     func load(path: AbsolutePath, context: GraphLoaderContexting) throws -> JSON {
-        guard let swiftOutput = try context.shell.run("xcrun", "-f", "swift").chuzzle() else {
-            throw GraphManifestLoaderError.swiftNotFound
-        }
-        let swiftPath = AbsolutePath(swiftOutput)
         let manifestFrameworkPath = try context.resourceLocator.projectDescription()
-        let jsonString: String! = try context.shell.run(swiftPath.asString, "-F",
-                                                        manifestFrameworkPath.parentDirectory.asString,
-                                                        "-framework", "ProjectDescription",
-                                                        path.asString, "--dump").chuzzle()
+        var arguments: [String] = [
+            "xcrun", "swift",
+            "-module-name", "Manifest",
+            "-F", manifestFrameworkPath.parentDirectory.asString,
+            "-framework", "ProjectDescription",
+        ]
+        arguments.append(contentsOf: try moduleLoader.load(path, context: context).map({ $0.asString }))
+        arguments.append("--dump")
+        let jsonString: String! = try context.shell.run(arguments, environment: ["DUMP": "1"]).chuzzle()
         if jsonString == nil {
             throw GraphManifestLoaderError.unexpectedOutput(path)
         }

--- a/App/xcbuddykit/Sources/Loader/GraphModuleLoader.swift
+++ b/App/xcbuddykit/Sources/Loader/GraphModuleLoader.swift
@@ -1,0 +1,79 @@
+import Basic
+import Foundation
+
+enum GraphModuleLoaderError: FatalError {
+    case fileNotFound(AbsolutePath)
+    case fileLoadError(AbsolutePath, Error)
+
+    /// Error type.
+    var type: ErrorType {
+        switch self {
+        case .fileNotFound:
+            return .abort
+        case .fileLoadError:
+            return .bugSilent
+        }
+    }
+
+    /// Error description.
+    var description: String {
+        switch self {
+        case let .fileNotFound(path):
+            return "Couldn't file file at path \(path)"
+        case let .fileLoadError(path):
+            return "Error loading file at path \(path)"
+        }
+    }
+}
+
+/// Interface of a module loader.
+protocol GraphModuleLoading: AnyObject {
+    /// Given a path, it loads all the paths that should be part of the module.
+    /// Any file can include other files in the same module by adding a comment line at
+    /// the top:
+    ///    //include: ./shared.swift
+    /// Notice that the path needs to be relative to the file.
+    ///
+    /// - Parameter path: path whose module will be loaded.
+    /// - Parameter context: context.
+    /// - Returns: list of files that should be part of the module.
+    func load(_ path: AbsolutePath, context: Contexting) throws -> Set<AbsolutePath>
+}
+
+final class GraphModuleLoader: GraphModuleLoading {
+    /// Given a path, it loads all the paths that should be part of the module.
+    /// Any file can include other files in the same module by adding a comment line at
+    /// the top:
+    ///    //include: ./shared.swift
+    /// Notice that the path needs to be relative to the file.
+    ///
+    /// TODO: Detect circular dependencies
+    ///
+    /// - Parameter path: path whose module will be loaded.
+    /// - Parameter context: context.
+    /// - Returns: list of files that should be part of the module.
+    func load(_ path: AbsolutePath, context: Contexting) throws -> Set<AbsolutePath> {
+        var paths = Set<AbsolutePath>()
+        if !context.fileHandler.exists(path) {
+            throw GraphModuleLoaderError.fileNotFound(path)
+        }
+        paths.insert(path)
+        var content: String!
+        do {
+            content = try String(contentsOf: URL(fileURLWithPath: path.asString))
+        } catch {
+            throw GraphModuleLoaderError.fileLoadError(path, error)
+        }
+        // swiftlint:disable:next force_try
+        let regex = try! NSRegularExpression(pattern: "//include:\\s+\"?(.+)\"?", options: [])
+        let range = NSRange(location: 0, length: content.count)
+        let matches = regex.matches(in: content, options: [], range: range)
+        try matches.forEach { match in
+            let matchRange = match.range(at: 1)
+            let relativePath = RelativePath((content as NSString).substring(with: matchRange))
+            paths.formUnion(try load(path.parentDirectory.appending(relativePath),
+                                     context: context))
+        }
+        return paths
+    }
+}

--- a/App/xcbuddykit/Sources/Loader/GraphModuleLoader.swift
+++ b/App/xcbuddykit/Sources/Loader/GraphModuleLoader.swift
@@ -41,6 +41,11 @@ protocol GraphModuleLoading: AnyObject {
 }
 
 final class GraphModuleLoader: GraphModuleLoading {
+    
+    /// Regular expression used to identify include lines.
+    // swiftlint:disable:next force_try
+    static let regex = try! NSRegularExpression(pattern: "//\\s*include:\\s+\"?(.+)\"?", options: [])
+    
     /// Given a path, it loads all the paths that should be part of the module.
     /// Any file can include other files in the same module by adding a comment line at
     /// the top:
@@ -64,10 +69,8 @@ final class GraphModuleLoader: GraphModuleLoading {
         } catch {
             throw GraphModuleLoaderError.fileLoadError(path, error)
         }
-        // swiftlint:disable:next force_try
-        let regex = try! NSRegularExpression(pattern: "//include:\\s+\"?(.+)\"?", options: [])
         let range = NSRange(location: 0, length: content.count)
-        let matches = regex.matches(in: content, options: [], range: range)
+        let matches = GraphModuleLoader.regex.matches(in: content, options: [], range: range)
         try matches.forEach { match in
             let matchRange = match.range(at: 1)
             let relativePath = RelativePath((content as NSString).substring(with: matchRange))

--- a/App/xcbuddykit/Sources/Loader/GraphModuleLoader.swift
+++ b/App/xcbuddykit/Sources/Loader/GraphModuleLoader.swift
@@ -41,28 +41,37 @@ protocol GraphModuleLoading: AnyObject {
 }
 
 final class GraphModuleLoader: GraphModuleLoading {
-    
     /// Regular expression used to identify include lines.
     // swiftlint:disable:next force_try
     static let regex = try! NSRegularExpression(pattern: "//\\s*include:\\s+\"?(.+)\"?", options: [])
-    
+
     /// Given a path, it loads all the paths that should be part of the module.
     /// Any file can include other files in the same module by adding a comment line at
     /// the top:
     ///    //include: ./shared.swift
     /// Notice that the path needs to be relative to the file.
     ///
-    /// TODO: Detect circular dependencies
-    ///
     /// - Parameter path: path whose module will be loaded.
     /// - Parameter context: context.
     /// - Returns: list of files that should be part of the module.
     func load(_ path: AbsolutePath, context: Contexting) throws -> Set<AbsolutePath> {
         var paths = Set<AbsolutePath>()
+        try load(path, paths: &paths, context: context)
+        return paths
+    }
+
+    /// Recursive method that traverses the module files and adds its paths to the given paths set.
+    ///
+    /// - Parameters:
+    ///   - path: path to be inspected.
+    ///   - paths: set that contains the module paths.
+    ///   - context: context.
+    fileprivate func load(_ path: AbsolutePath, paths: inout Set<AbsolutePath>, context: Contexting) throws {
+        var paths = Set<AbsolutePath>()
         if !context.fileHandler.exists(path) {
             throw GraphModuleLoaderError.fileNotFound(path)
         }
-        paths.insert(path)
+        if paths.contains(path) { return }
         var content: String!
         do {
             content = try String(contentsOf: URL(fileURLWithPath: path.asString))
@@ -74,9 +83,9 @@ final class GraphModuleLoader: GraphModuleLoading {
         try matches.forEach { match in
             let matchRange = match.range(at: 1)
             let relativePath = RelativePath((content as NSString).substring(with: matchRange))
-            paths.formUnion(try load(path.parentDirectory.appending(relativePath),
-                                     context: context))
+            try load(path.parentDirectory.appending(relativePath),
+                     paths: &paths,
+                     context: context)
         }
-        return paths
     }
 }

--- a/App/xcbuddykit/Sources/Loader/GraphNode.swift
+++ b/App/xcbuddykit/Sources/Loader/GraphNode.swift
@@ -163,7 +163,7 @@ class PrecompiledNode: GraphNode {
     /// - Returns: list of architectures.
     /// - Throws: an error if architectures cannot be obtained for the framework/library.
     func architectures(shell: Shelling) throws -> [Architecture] {
-        let output = try shell.run("lipo -info \(binaryPath.asString)")
+        let output = try shell.run("lipo -info \(binaryPath.asString)", environment: [:])
         let regex = try NSRegularExpression(pattern: ".+:\\s.+\\sis\\sarchitecture:\\s(.+)", options: [])
         guard let match = regex.firstMatch(in: output, options: [], range: NSRange(location: 0, length: output.count)) else {
             throw PrecompiledNodeError.architecturesNotFound(binaryPath)
@@ -178,7 +178,7 @@ class PrecompiledNode: GraphNode {
     /// - Returns: linking type.
     /// - Throws: throws an error if the linking cannot be obtained for the framework/library.
     func linking(shell: Shelling) throws -> Linking {
-        let output = try shell.run("file \(binaryPath.asString)")
+        let output = try shell.run("file \(binaryPath.asString)", environment: [:])
         return output.contains("dynamically linked") ? .dynamic : .static
     }
 }

--- a/App/xcbuddykit/Sources/Utils/CommandCheck.swift
+++ b/App/xcbuddykit/Sources/Utils/CommandCheck.swift
@@ -24,8 +24,7 @@ enum CommandCheckError: FatalError, Equatable {
     /// Error type.
     var type: ErrorType {
         switch self {
-        case .incompatibleSwiftVersion: fallthrough
-        case .swiftVersionNotFound:
+        case .incompatibleSwiftVersion, .swiftVersionNotFound:
             return .abort
         }
     }
@@ -81,7 +80,7 @@ final class CommandCheck: CommandChecking {
     ///
     /// - Throws: an error if the versions don't match.
     func swiftVersionCompatibility() throws {
-        let output = try context.shell.run("swift", "--version").chomp()
+        let output = try context.shell.run("xcrun", "swift", "--version", environment: [:]).chomp()
         let regex = try NSRegularExpression(pattern: "Apple\\sSwift\\sversion\\s(\\d+\\.\\d+(\\.\\d+)?)", options: [])
         guard let versionMatch = regex.firstMatch(in: output, options: [], range: NSRange(location: 0, length: output.count)) else {
             throw CommandCheckError.swiftVersionNotFound

--- a/App/xcbuddykit/Sources/Utils/FileAggregator.swift
+++ b/App/xcbuddykit/Sources/Utils/FileAggregator.swift
@@ -1,0 +1,44 @@
+import Basic
+import Foundation
+
+/// A file aggregator aggregates the content of multiple files.
+protocol FileAggregating: AnyObject {
+    /// Aggreates the files at the given paths.
+    ///
+    /// - Parameters:
+    ///   - paths: paths whose content will be aggregated.
+    ///   - into: path of the file where the contents will be aggregated into.
+    /// - Throws: an error if the aggregation fails.
+    func aggregate(_ paths: [AbsolutePath], into: AbsolutePath) throws
+}
+
+/// Default file aggreagtor.
+final class FileAggregator: FileAggregating {
+    /// Aggreates the files at the given paths.
+    ///
+    /// - Parameters:
+    ///   - paths: paths whose content will be aggregated.
+    ///   - into: path of the file where the contents will be aggregated into.
+    /// - Throws: an error if the aggregation fails.
+    func aggregate(_ paths: [AbsolutePath], into: AbsolutePath) throws {
+        var paths = paths
+        if paths.count == 0 { return }
+        let outputStream = OutputStream(toFileAtPath: into.asString, append: true)!
+        outputStream.open()
+        let first = paths.removeFirst()
+        try Data(contentsOf: URL(fileURLWithPath: first.asString)).write(into: outputStream)
+        try paths.forEach { path in
+            "\n".data(using: .utf8)!.write(into: outputStream)
+            try Data(contentsOf: URL(fileURLWithPath: path.asString)).write(into: outputStream)
+        }
+        outputStream.close()
+    }
+}
+
+fileprivate extension Data {
+    func write(into: OutputStream) {
+        _ = withUnsafeBytes {
+            into.write($0, maxLength: self.count)
+        }
+    }
+}

--- a/App/xcbuddykit/Sources/Utils/Shell.swift
+++ b/App/xcbuddykit/Sources/Utils/Shell.swift
@@ -15,21 +15,45 @@ struct ShellError: FatalError, Equatable {
 protocol Shelling: AnyObject {
     /// Runs a shell command synchronously and returns the output.
     ///
+    /// - Parameters:
     /// - Parameter args: shell command to be run.
+    ///   - environment: environment.
     /// - Returns: the command output.
     /// - Throws: an error if the execution fails.
-    func run(_ args: String...) throws -> String
+    func run(_ args: String..., environment: [String: String]) throws -> String
+
+    /// Runs a shell command synchronously and returns the output.
+    ///
+    /// - Parameters:
+    /// - Parameter args: shell command to be run.
+    ///   - environment: environment.
+    /// - Returns: the command output.
+    /// - Throws: an error if the execution fails.
+    func run(_ args: [String], environment: [String: String]) throws -> String
 }
 
 /// Default implementation of Shelling.
 class Shell: Shelling {
     /// Runs a shell command synchronously and returns the output.
     ///
+    /// - Parameters:
     /// - Parameter args: shell command to be run.
+    ///   - environment: environment.
     /// - Returns: the command output.
     /// - Throws: an error if the execution fails.
-    func run(_ args: String...) throws -> String {
-        let result = try Process.popen(arguments: args)
+    func run(_ args: String..., environment: [String: String] = [:]) throws -> String {
+        return try run(args, environment: environment)
+    }
+
+    /// Runs a shell command synchronously and returns the output.
+    ///
+    /// - Parameters:
+    /// - Parameter args: shell command to be run.
+    ///   - environment: environment.
+    /// - Returns: the command output.
+    /// - Throws: an error if the execution fails.
+    func run(_ args: [String], environment: [String: String] = [:]) throws -> String {
+        let result = try Process.popen(arguments: args, environment: environment)
         if result.exitStatus == .terminated(code: 0) {
             return try result.utf8Output()
         } else {

--- a/App/xcbuddykit/Tests/Loader/GraphManifestLoaderTests.swift
+++ b/App/xcbuddykit/Tests/Loader/GraphManifestLoaderTests.swift
@@ -14,11 +14,6 @@ final class GraphManifestLoaderErrorTests: XCTestCase {
         XCTAssertEqual(error.description, "Couldn't find the Frameworks folder in the bundle that contains the ProjectDescription.framework.")
     }
 
-    func test_description_when_swiftNotFound() {
-        let error = GraphManifestLoaderError.swiftNotFound
-        XCTAssertEqual(error.description, "Couldn't find Swift on your environment. Run 'xcode-select -p' to see if the Xcode path is properly setup.")
-    }
-
     func test_description_when_unexpectedOutput() {
         let error = GraphManifestLoaderError.unexpectedOutput(AbsolutePath("/test/"))
         XCTAssertEqual(error.description, "Unexpected output trying to parse the manifest at path /test.")

--- a/App/xcbuddykit/Tests/Loader/GraphModuleLoaderTests.swift
+++ b/App/xcbuddykit/Tests/Loader/GraphModuleLoaderTests.swift
@@ -1,0 +1,65 @@
+import Basic
+import Foundation
+@testable import xcbuddykit
+import XCTest
+
+final class GraphModuleLoaderErrorTests: XCTestCase {
+    func test_type_when_fileNotFound() {
+        let path = AbsolutePath("/test")
+        let error = GraphModuleLoaderError.fileNotFound(path)
+        XCTAssertEqual(error.type, .abort)
+    }
+
+    func test_type_when_fileLoadError() {
+        let path = AbsolutePath("/test")
+        let error = GraphModuleLoaderError.fileLoadError(path, NSError(domain: "", code: -1, userInfo: nil))
+        XCTAssertEqual(error.type, .bugSilent)
+    }
+
+    func test_description_when_fileNotFound() {
+        let path = AbsolutePath("/test")
+        let error = GraphModuleLoaderError.fileNotFound(path)
+        XCTAssertEqual(error.description, "File not found at path \(path.asString)")
+    }
+
+    func test_description_when_fileLoadError() {
+        let path = AbsolutePath("/test")
+        let error = GraphModuleLoaderError.fileLoadError(path, NSError(domain: "", code: -1, userInfo: nil))
+        XCTAssertEqual(error.description, "Error loading file at path \(path.asString)")
+    }
+}
+
+final class GraphModuleLoaderTests: XCTestCase {
+    var tmpDir: TemporaryDirectory!
+    var subject: GraphModuleLoader!
+    var context: Context!
+
+    override func setUp() {
+        super.setUp()
+        tmpDir = try! TemporaryDirectory()
+        subject = GraphModuleLoader()
+        context = Context()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        tmpDir = nil
+    }
+
+    func test_load() throws {
+        let mainSwiftPath = tmpDir.path.appending(component: "main.swift")
+        let sharedSwiftPath = tmpDir.path.appending(component: "shared.swift")
+        try "//include: ./shared.swift".write(to: URL(fileURLWithPath: mainSwiftPath.asString), atomically: true, encoding: .utf8)
+        try "".write(to: URL(fileURLWithPath: sharedSwiftPath.asString), atomically: true, encoding: .utf8)
+        let got = try subject.load(mainSwiftPath, context: context)
+        XCTAssertTrue(got.contains(mainSwiftPath))
+        XCTAssertTrue(got.contains(sharedSwiftPath))
+    }
+
+    func test_load_throws_when_theFileDoesntExist() throws {
+        let path = tmpDir.path.appending(component: "main.swift")
+        XCTAssertThrowsError(try subject.load(path, context: context)) {
+            XCTAssertEqual($0 as? GraphModuleLoaderError, GraphModuleLoaderError.fileNotFound(path))
+        }
+    }
+}

--- a/App/xcbuddykit/Tests/Loader/GraphNodeTests.swift
+++ b/App/xcbuddykit/Tests/Loader/GraphNodeTests.swift
@@ -36,7 +36,7 @@ final class FrameworkNodeTests: XCTestCase {
     }
 
     func test_architectures() throws {
-        shell.runStub = { command in
+        shell.runStub = { command, _ in
             if command.joined(separator: " ") == "lipo -info /test.framework/test" {
                 return "Non-fat file: path is architecture: x86_64"
             }
@@ -46,7 +46,7 @@ final class FrameworkNodeTests: XCTestCase {
     }
 
     func test_linking() {
-        shell.runStub = { command in
+        shell.runStub = { command, _ in
             if command.joined(separator: " ") == "file /test.framework/test" {
                 return "whatever dynamically linked"
             }
@@ -73,7 +73,7 @@ final class LibraryNodeTests: XCTestCase {
     }
 
     func test_architectures() throws {
-        shell.runStub = { command in
+        shell.runStub = { command, _ in
             if command.joined(separator: " ") == "lipo -info /test.a" {
                 return "Non-fat file: path is architecture: x86_64"
             }
@@ -83,7 +83,7 @@ final class LibraryNodeTests: XCTestCase {
     }
 
     func test_linking() {
-        shell.runStub = { command in
+        shell.runStub = { command, _ in
             if command.joined(separator: " ") == "file /test.a" {
                 return "whatever dynamically linked"
             }

--- a/App/xcbuddykit/Tests/Loader/GraphTests.swift
+++ b/App/xcbuddykit/Tests/Loader/GraphTests.swift
@@ -117,7 +117,7 @@ final class GraphTests: XCTestCase {
         cache.add(targetNode: targetNode)
         let graph = Graph.test(cache: cache)
         let shell = MockShell()
-        shell.runStub = { _ in "dynamically linked" }
+        shell.runStub = { _, _ in "dynamically linked" }
         let got = try graph.embeddableFrameworks(path: project.path,
                                                  name: target.name,
                                                  shell: shell)
@@ -138,7 +138,7 @@ final class GraphTests: XCTestCase {
         cache.add(targetNode: targetNode)
         let graph = Graph.test(cache: cache)
         let shell = MockShell()
-        shell.runStub = { _ in "dynamically linked" }
+        shell.runStub = { _, _ in "dynamically linked" }
         let got = try graph.embeddableFrameworks(path: project.path,
                                                  name: target.name,
                                                  shell: shell)
@@ -157,7 +157,7 @@ final class GraphTests: XCTestCase {
         cache.add(targetNode: targetNode)
         let graph = Graph.test(cache: cache)
         let shell = MockShell()
-        shell.runStub = { _ in "dynamically linked" }
+        shell.runStub = { _, _ in "dynamically linked" }
         let got = try graph.embeddableFrameworks(path: project.path,
                                                  name: target.name,
                                                  shell: shell)

--- a/App/xcbuddykit/Tests/Loader/Mocks/MockGraphModuleLoader.swift
+++ b/App/xcbuddykit/Tests/Loader/Mocks/MockGraphModuleLoader.swift
@@ -1,0 +1,15 @@
+import Basic
+import Foundation
+@testable import xcbuddykit
+import XCTest
+
+final class MockGraphModuleLoader: GraphModuleLoading {
+    var loadCount: UInt = 0
+    var loadStub: ((AbsolutePath, Contexting) -> Set<AbsolutePath>)?
+
+    func load(_ path: AbsolutePath,
+              context: Contexting) throws -> Set<AbsolutePath> {
+        loadCount += 1
+        return loadStub?(path, context) ?? Set()
+    }
+}

--- a/App/xcbuddykit/Tests/Loader/Mocks/MockGraphModuleLoader.swift
+++ b/App/xcbuddykit/Tests/Loader/Mocks/MockGraphModuleLoader.swift
@@ -5,11 +5,11 @@ import XCTest
 
 final class MockGraphModuleLoader: GraphModuleLoading {
     var loadCount: UInt = 0
-    var loadStub: ((AbsolutePath, Contexting) -> Set<AbsolutePath>)?
+    var loadStub: ((AbsolutePath, Contexting) -> [AbsolutePath])?
 
     func load(_ path: AbsolutePath,
-              context: Contexting) throws -> Set<AbsolutePath> {
+              context: Contexting) throws -> [AbsolutePath] {
         loadCount += 1
-        return loadStub?(path, context) ?? Set()
+        return loadStub?(path, context) ?? []
     }
 }

--- a/App/xcbuddykit/Tests/Utils/CommandCheckTests.swift
+++ b/App/xcbuddykit/Tests/Utils/CommandCheckTests.swift
@@ -31,7 +31,7 @@ final class CommandCheckTests: XCTestCase {
     }
 
     func test_swiftVersionCompatibility_throws_whenSwiftVersionNotFound() {
-        shell.runStub = { _ in
+        shell.runStub = { _, _ in
             "this is an invalid output"
         }
         XCTAssertThrowsError(try subject.swiftVersionCompatibility()) { error in
@@ -40,8 +40,8 @@ final class CommandCheckTests: XCTestCase {
     }
 
     func test_swiftVeresionCompatibility_throws_whenSwiftVersionsAreNotEqual() {
-        shell.runStub = { command in
-            if command == ["swift", "--version"] {
+        shell.runStub = { command, _ in
+            if command == ["xcrun", "swift", "--version"] {
                 return "Apple Swift version 3.0 (swiftlang-902.0.48 clang-902.0.37.1)"
             }
             return ""

--- a/App/xcbuddykit/Tests/Utils/FileAggregatorTests.swift
+++ b/App/xcbuddykit/Tests/Utils/FileAggregatorTests.swift
@@ -1,0 +1,29 @@
+import Basic
+import Foundation
+@testable import xcbuddykit
+import XCTest
+
+final class FileAggregatorTests: XCTestCase {
+    var subject: FileAggregator!
+
+    override func setUp() {
+        super.setUp()
+        subject = FileAggregator()
+    }
+
+    func test_aggregate() throws {
+        let dir = try TemporaryDirectory()
+        let aPath = dir.path.appending(component: "a.swift")
+        let bPath = dir.path.appending(component: "b.swift")
+        try "a".write(toFile: aPath.asString,
+                      atomically: true,
+                      encoding: .utf8)
+        try "b".write(toFile: bPath.asString,
+                      atomically: true,
+                      encoding: .utf8)
+        let cPath = dir.path.appending(component: "c.swift")
+        try subject.aggregate([aPath, bPath], into: cPath)
+        let content = try String(contentsOf: URL(fileURLWithPath: cPath.asString))
+        XCTAssertEqual(content, "a\nb")
+    }
+}

--- a/App/xcbuddykit/Tests/Utils/Mocks/MockShell.swift
+++ b/App/xcbuddykit/Tests/Utils/Mocks/MockShell.swift
@@ -2,11 +2,16 @@ import Foundation
 @testable import xcbuddykit
 
 class MockShell: Shelling {
-    var runStub: (([String]) throws -> String)?
+    var runStub: (([String], [String: String]) throws -> String)?
     var runArgs: [[String]] = []
 
-    func run(_ args: String...) throws -> String {
+    func run(_ args: String..., environment: [String: String]) throws -> String {
         runArgs.append(args)
-        return try runStub?(args) ?? ""
+        return try runStub?(args, environment) ?? ""
+    }
+
+    func run(_ args: [String], environment: [String: String]) throws -> String {
+        runArgs.append(args)
+        return try runStub?(args, environment) ?? ""
     }
 }


### PR DESCRIPTION
### Short description 📝
This PR adds support for modules. A manifest file can include other Swift files by just adding:

```swift
// Project.swift
//include ./Shared.swift
```
This makes reusability possible 🎉 

### Implementation 👩‍💻👨‍💻
- [x] Implement `GraphModuleLoader`
- [x] Add `MockGraphModuleLoader`.
- [x] Use it from `GraphManifestLoader`.
- [x] Use it from `TargetGenerator` to include all the files of the module.